### PR TITLE
bug fix for SS5

### DIFF
--- a/src/SmtpTester.php
+++ b/src/SmtpTester.php
@@ -122,6 +122,7 @@ class SmtpTester extends LeftAndMain implements PermissionProvider {
         try {
             $email = new Email($from,$to,$subject,$message);
             $status = $email->send();
+            $status = true;
         } catch (\Exception $e) {
             $status = false;
             $errorMessage = " Error Message: {$e->getMessage()}";

--- a/src/SmtpTester.php
+++ b/src/SmtpTester.php
@@ -121,7 +121,7 @@ class SmtpTester extends LeftAndMain implements PermissionProvider {
 
         try {
             $email = new Email($from,$to,$subject,$message);
-            $status = $email->send();
+            $email->send();
             $status = true;
         } catch (\Exception $e) {
             $status = false;


### PR DESCRIPTION
set status to true after email is sent. send method no longer returns a bool in SS5