### PR TITLE
admin_email is not correctly being pulled and used.

### DIFF
--- a/src/SmtpTester.php
+++ b/src/SmtpTester.php
@@ -72,9 +72,10 @@ class SmtpTester extends LeftAndMain implements PermissionProvider {
     public function SmtpTesterForm() {
         $siteName = SiteConfig::current_site_config()->Title;
         $memberEmail = Security::getCurrentUser()->Email;
-        $adminEmail = Config::inst()->get('Email', 'admin_email');
+        $adminEmail = Config::inst()->get('SilverStripe\Control\Email\Email', 'admin_email');
         $fieldsArr = array();
 
+        $adminEmail = is_array($adminEmail) ? array_key_first($adminEmail) : $adminEmail;
         if (!filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
             $adminEmail = "test@".str_replace(Director::protocol(),"",Director::protocolAndHost());
         }


### PR DESCRIPTION
"admin_email" is unable to be retrieved because the Email class is not correctly namespaced.

In addition, the "admin_email" value is optionally an array containing the email and the name of the user (e.g. [ 'admin@example.com' => 'admin joe' ]). This will however fail the "filter_var" test for email. So, if the value is an array, just grab and use the email.